### PR TITLE
SF-3434: Masking Authorization Header

### DIFF
--- a/src/main/java/com/stackify/log/servlet/HttpServletRequests.java
+++ b/src/main/java/com/stackify/log/servlet/HttpServletRequests.java
@@ -4,9 +4,7 @@
  */
 package com.stackify.log.servlet;
 
-import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
@@ -25,6 +23,24 @@ public class HttpServletRequests {
 	 * Value Mask
 	 */
 	private static final String MASKED = "X-MASKED-X";
+
+    /**
+     * Value Mask set
+     */
+	private static final Set<String> MASKED_SET = initializeMaskSet();
+    
+    /**
+     * Returns an initialized set with all headers that need to be masked.
+     * @return Initialized Set of Header Key Names
+     */
+    public static Set<String> initializeMaskSet() {
+        Set<String> maskSet = new HashSet<String>();
+
+        maskSet.add("cookie");
+        maskSet.add("authorization");
+
+        return maskSet;
+    }
 	
 	/**
 	 * Gets a WebRequestDetail from the servlet request
@@ -98,7 +114,7 @@ public class HttpServletRequests {
 				
 				String name = headerNames.nextElement();
 				
-				if (name.equalsIgnoreCase("cookie")) {
+				if (MASKED_SET.contains(name)) {
 					
 					headerMap.put(name, MASKED);
 					

--- a/src/main/java/com/stackify/log/servlet/HttpServletRequests.java
+++ b/src/main/java/com/stackify/log/servlet/HttpServletRequests.java
@@ -4,7 +4,6 @@
  */
 package com.stackify.log.servlet;
 
-import java.util.*;
 
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
@@ -12,6 +11,12 @@ import javax.servlet.http.HttpSession;
 
 import com.stackify.api.WebRequestDetail;
 import com.stackify.api.common.util.Preconditions;
+
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * HttpServletRequests
@@ -28,7 +33,7 @@ public class HttpServletRequests {
      * Value Mask set
      */
 	private static final Set<String> MASKED_SET = initializeMaskSet();
-    
+
     /**
      * Returns an initialized set with all headers that need to be masked.
      * @return Initialized Set of Header Key Names
@@ -104,7 +109,7 @@ public class HttpServletRequests {
 		Preconditions.checkNotNull(request);
 
 		@SuppressWarnings("unchecked")
-		Enumeration<String> headerNames = request.getHeaderNames();
+        Enumeration<String> headerNames = request.getHeaderNames();
 		
 		if ((headerNames != null) && (headerNames.hasMoreElements())) {
 			

--- a/src/test/java/com/stackify/log/servlet/HttpServletRequestsTest.java
+++ b/src/test/java/com/stackify/log/servlet/HttpServletRequestsTest.java
@@ -7,6 +7,7 @@ package com.stackify.log.servlet;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
@@ -105,6 +106,7 @@ public class HttpServletRequestsTest {
 		
 		List<String> headerNames = new ArrayList<String>();
 		headerNames.add("cookie");
+		headerNames.add("authorization");
 		headerNames.add("h");
 		headerNames.add("multitest");
 		
@@ -118,11 +120,24 @@ public class HttpServletRequestsTest {
 		Mockito.when(request.getHeaders("multitest")).thenReturn(Collections.enumeration(multitest));
 
 		WebRequestDetail wrd = HttpServletRequests.getWebRequest(request);		
-		Assert.assertEquals(3, wrd.getHeaders().size());
+		Assert.assertEquals(4, wrd.getHeaders().size());
 		Assert.assertEquals("X-MASKED-X", wrd.getHeaders().get("cookie"));
+		Assert.assertEquals("X-MASKED-X", wrd.getHeaders().get("authorization"));
 		Assert.assertEquals("v", wrd.getHeaders().get("h"));
 		Assert.assertEquals("a,b,c", wrd.getHeaders().get("multitest"));
 	}
+
+    /**
+     * testHeaderMaskSet
+     */
+    @Test
+    public void testHeaderMaskSet() {
+        Set<String> maskSet = HttpServletRequests.initializeMaskSet();
+
+        Assert.assertEquals(2, maskSet.size());
+        Assert.assertTrue(maskSet.contains("cookie"));
+        Assert.assertTrue(maskSet.contains("authorization"));
+    }
 	
 	/**
 	 * testCookies


### PR DESCRIPTION
Added implementation to check for configured masked header names. If the header is configured, then the value is masked before it is sent.
